### PR TITLE
Add convenience accessors for various pieces of the request.

### DIFF
--- a/Sources/Alchemy/Core/Application+HTTP/HTTPBody.swift
+++ b/Sources/Alchemy/Core/Application+HTTP/HTTPBody.swift
@@ -61,9 +61,23 @@ public struct HTTPBody: ExpressibleByStringLiteral {
             return Data.init(buffer: buffer)
         }
     }
+}
+
+extension HTTPBody {
+    /// Decodes the body as a `String`.
+    public func decodeString(with encoding: String.Encoding = .utf8) -> String? {
+        String(data: self.data, encoding: encoding)
+    }
     
-    /// Decodes the body as JSON into the provided Decodable type
-    public func decodeJSON<D: Decodable>(as type: D.Type) throws -> D {
-        return try JSONDecoder().decode(type, from: data)
+    /// Decodes the body as a JSON dictionary.
+    public func decodeJSONDictionary() throws -> [String: Any]? {
+        try JSONSerialization.jsonObject(with: self.data, options: []) as? [String: Any]
+    }
+    
+    /// Decodes the body as JSON into the provided Decodable type, with the optionally provided `JSONDecoder`.
+    public func decodeJSON<D: Decodable>(as type: D.Type, with decoder: JSONDecoder = JSONDecoder())
+        throws -> D
+    {
+        return try decoder.decode(type, from: data)
     }
 }

--- a/Sources/Alchemy/Core/Application+HTTP/HTTPRequest.swift
+++ b/Sources/Alchemy/Core/Application+HTTP/HTTPRequest.swift
@@ -12,11 +12,11 @@ public struct HTTPRequest {
     /// The headers are also found in the head, and they are often used to describe the body as well
     public let head: HTTPRequestHead
     
+    /// The url components of this request.
+    public let components: URLComponents?
+    
     /// The bodyBuffer is internal because the HTTPBody API is exposed for simpler access
     var bodyBuffer: ByteBuffer?
-    
-    /// The components of the url of this request.
-    var components: URLComponents?
     
     /// This initializer is necessary because the `bodyBuffer` is a private property
     init(eventLoop: EventLoop, head: HTTPRequestHead, bodyBuffer: ByteBuffer?) {

--- a/Sources/Alchemy/Core/Application+HTTP/HTTPRequest.swift
+++ b/Sources/Alchemy/Core/Application+HTTP/HTTPRequest.swift
@@ -1,3 +1,4 @@
+import Foundation
 import NIO
 import NIOHTTP1
 
@@ -14,14 +15,40 @@ public struct HTTPRequest {
     /// The bodyBuffer is internal because the HTTPBody API is exposed for simpler access
     var bodyBuffer: ByteBuffer?
     
+    /// The components of the url of this request.
+    var components: URLComponents?
+    
     /// This initializer is necessary because the `bodyBuffer` is a private property
     init(eventLoop: EventLoop, head: HTTPRequestHead, bodyBuffer: ByteBuffer?) {
         self.eventLoop = eventLoop
         self.head = head
         self.bodyBuffer = bodyBuffer
+        self.components = URLComponents(string: head.uri)
+    }
+}
+
+extension HTTPRequest {
+    /// The HTTPMethod of the request.
+    public var method: HTTPMethod {
+        self.head.method
     }
     
-    /// The body is a wrapped used to provide simpler access to body data like JSON
+    /// The path of the request. Does not include the query string.
+    public var path: String {
+        self.components?.path ?? ""
+    }
+    
+    /// Any headers associated with the request.
+    public var headers: HTTPHeaders {
+        self.head.headers
+    }
+    
+    /// Any query items parsed from the URL. These are not percent encoded.
+    public var queryItems: [URLQueryItem] {
+        self.components?.queryItems ?? []
+    }
+    
+    /// The body is a wrapper used to provide simpler access to body data like JSON.
     public var body: HTTPBody? {
         guard let bodyBuffer = bodyBuffer else {
             return nil

--- a/Sources/Alchemy/Core/Application+HTTP/HTTPRequestHead+QueryComponents.swift
+++ b/Sources/Alchemy/Core/Application+HTTP/HTTPRequestHead+QueryComponents.swift
@@ -1,0 +1,9 @@
+import Foundation
+import NIO
+import NIOHTTP1
+
+extension HTTPRequestHead {
+    public func getQueryItems() -> [URLQueryItem] {
+        URLComponents(string: self.uri)?.percentEncodedQueryItems ?? []
+    }
+}

--- a/Sources/Alchemy/Core/Application+HTTP/HTTPRequestHead+QueryComponents.swift
+++ b/Sources/Alchemy/Core/Application+HTTP/HTTPRequestHead+QueryComponents.swift
@@ -1,9 +1,0 @@
-import Foundation
-import NIO
-import NIOHTTP1
-
-extension HTTPRequestHead {
-    public func getQueryItems() -> [URLQueryItem] {
-        URLComponents(string: self.uri)?.percentEncodedQueryItems ?? []
-    }
-}

--- a/Sources/Alchemy/ORM/Database/Database.swift
+++ b/Sources/Alchemy/ORM/Database/Database.swift
@@ -1,6 +1,6 @@
 import PostgresKit
 
-public class Database<Kind> {
+public class Database {
     let config: DatabaseConfig
     let pool: ConnectionPool
     

--- a/Sources/Alchemy/ORM/Database/Kinds/MongoDB.swift
+++ b/Sources/Alchemy/ORM/Database/Kinds/MongoDB.swift
@@ -1,25 +1,6 @@
 /// This isn't working, just an example of adding a custom db.
 
-/// Add a type representing this kind of Database.
-public enum MongoDB { }
-
 /// Add a Database class with `Kind` as the kind type above.
-public final class MongoDatabase: Database<MongoDB> {
+public final class MongoDatabase: Database {
     // Can optionally override any function such as setup, query, etc.
-}
-
-/// Then, potentially write a custom query builder for a `MongoDB` database.
-/// (assuming general query builder looks something like this)
-protocol QueryBuilder {
-    associatedtype Kind
-    func toString() -> String
-}
-
-struct MongoBuilder: QueryBuilder {
-    // Assuming QueryBuilder has associated type `Kind`
-    public typealias Kind = MongoDB
-    
-    func toString() -> String {
-        "db.collectionname.find( {} )"
-    }
 }

--- a/Sources/Alchemy/ORM/Database/Kinds/MySQL.swift
+++ b/Sources/Alchemy/ORM/Database/Kinds/MySQL.swift
@@ -2,4 +2,4 @@ public enum MySQL { }
 
 // Not working at the moment, seems like https://github.com/vapor/mysql-nio has some larger updates coming
 // soon.
-public final class MySQLDatabase: Database<MySQL> { }
+public final class MySQLDatabase: Database { }

--- a/Sources/Alchemy/ORM/Database/Kinds/PostgreSQL.swift
+++ b/Sources/Alchemy/ORM/Database/Kinds/PostgreSQL.swift
@@ -1,3 +1,3 @@
 public enum PostgreSQL { }
 
-public final class PostgresDatabase: Database<PostgreSQL> { }
+public final class PostgresDatabase: Database { }

--- a/Sources/_Example/ExampleApplication.swift
+++ b/Sources/_Example/ExampleApplication.swift
@@ -63,7 +63,7 @@ struct DatabaseTestController {
     }
 }
 
-struct SampleJSON: Encodable {
+struct SampleJSON: Codable {
     let one = "value1"
     let two = "value2"
     let three = "value3"
@@ -74,6 +74,14 @@ struct LoggingMiddleware: Middleware {
     let text: String
     
     func intercept(_ request: HTTPRequest) throws -> Void {
-        print("\(self.text) '\(request.head.method.rawValue) \(request.head.uri)'")
+        print("""
+            METHOD: \(request.method)
+            PATH: \(request.path)
+            HEADERS: \(request.headers)
+            QUERY: \(request.queryItems)
+            BODY_STRING: \(request.body?.decodeString() ?? "N/A")
+            BODY_DICT: \(try request.body?.decodeJSONDictionary() ?? [:])
+            BODY_TYPE: \(try request.body?.decodeJSON(as: SampleJSON.self))
+            """)
     }
 }

--- a/Sources/_Example/ExampleApplication.swift
+++ b/Sources/_Example/ExampleApplication.swift
@@ -75,6 +75,7 @@ struct LoggingMiddleware: Middleware {
     
     func intercept(_ request: HTTPRequest) throws -> Void {
         print("""
+            \(self.text)
             METHOD: \(request.method)
             PATH: \(request.path)
             HEADERS: \(request.headers)


### PR DESCRIPTION
To `HTTPRequest` add...
`components: URLComponents?`
`method: HTTPMethod`
`path: String`
`headers: HTTPHeaders`
`queryItems: [URLQueryItem]`

To `HTTPBody` add...
`decodeString `
`decodeJSONDictionary`
`decodeJSON<D: Decodable>`

Also remove the `<Kind>` requirement from `Database`.