### PR TITLE
Add path parameters

### DIFF
--- a/Sources/Alchemy/Core/Application+HTTP/HTTPRequest.swift
+++ b/Sources/Alchemy/Core/Application+HTTP/HTTPRequest.swift
@@ -2,6 +2,14 @@ import Foundation
 import NIO
 import NIOHTTP1
 
+/// Represents a dynamic parameter inside the URL. Something like `:user_id` in the path `/v1/users/:user_id`.
+public struct PathParameter: Equatable {
+    /// The escaped parameter that was matched. Something like `:user_id`
+    public let parameter: String
+    /// The actual string value of the parameter.
+    public let stringValue: String
+}
+
 /// A simplified HTTPRequest type as you'll come across in many web frameworks
 public struct HTTPRequest {
     /// The EventLoop is stored in the HTTP request so that promises can be created
@@ -14,6 +22,9 @@ public struct HTTPRequest {
     
     /// The url components of this request.
     public let components: URLComponents?
+    
+    /// The any parameters inside the path.
+    public var pathParameters: [PathParameter] = []
     
     /// The bodyBuffer is internal because the HTTPBody API is exposed for simpler access
     var bodyBuffer: ByteBuffer?

--- a/Sources/Alchemy/Core/Application+HTTP/HTTPRequest.swift
+++ b/Sources/Alchemy/Core/Application+HTTP/HTTPRequest.swift
@@ -2,14 +2,6 @@ import Foundation
 import NIO
 import NIOHTTP1
 
-/// Represents a dynamic parameter inside the URL. Something like `:user_id` in the path `/v1/users/:user_id`.
-public struct PathParameter: Equatable {
-    /// The escaped parameter that was matched. Something like `:user_id`
-    public let parameter: String
-    /// The actual string value of the parameter.
-    public let stringValue: String
-}
-
 /// A simplified HTTPRequest type as you'll come across in many web frameworks
 public struct HTTPRequest {
     /// The EventLoop is stored in the HTTP request so that promises can be created
@@ -57,6 +49,11 @@ extension HTTPRequest {
     /// Any query items parsed from the URL. These are not percent encoded.
     public var queryItems: [URLQueryItem] {
         self.components?.queryItems ?? []
+    }
+    
+    /// Returns the first `PathParameter` for the given key, if there is one.
+    public func pathParameter(named key: String) -> PathParameter? {
+        self.pathParameters.first(where: { $0.parameter == "key" })
     }
     
     /// The body is a wrapper used to provide simpler access to body data like JSON.

--- a/Sources/Alchemy/Core/Application+HTTP/PathParameter.swift
+++ b/Sources/Alchemy/Core/Application+HTTP/PathParameter.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Represents a dynamic parameter inside the URL. Something like `:user_id` in the path `/v1/users/:user_id`.
+public struct PathParameter: Equatable {
+    /// The escaped parameter that was matched. Something like `:user_id`
+    public let parameter: String
+    /// The actual string value of the parameter.
+    public let stringValue: String
+}
+
+extension PathParameter {
+    public struct Error: Swift.Error {
+        public let message: String
+    }
+    
+    /// Decodes a `UUID` from this parameter's value or throws a `PathParameter.Error`.
+    public func uuid() throws -> UUID {
+        try UUID(uuidString: self.stringValue)
+            .unwrap(or: Error(message: "Unable to decode UUID for '\(self.parameter)'. Value was '\(self.stringValue)'."))
+    }
+
+    /// Returns the string value of this parameter.
+    public func string() -> String {
+        self.stringValue
+    }
+    
+    /// Decodes an `Int` from this parameter's value or throws a `PathParameter.Error`.
+    public func int() throws -> Int {
+        try Int(self.stringValue)
+            .unwrap(or: Error(message: "Unable to decode Int for '\(self.parameter)'. Value was '\(self.stringValue)'."))
+    }
+}
+
+extension Optional {
+    func unwrap(or error: Error) throws -> Wrapped {
+        guard let wrapped = self else {
+            throw error
+        }
+        
+        return wrapped
+    }
+}

--- a/Sources/_Example/ExampleApplication.swift
+++ b/Sources/_Example/ExampleApplication.swift
@@ -82,7 +82,6 @@ struct LoggingMiddleware: Middleware {
             QUERY: \(request.queryItems)
             BODY_STRING: \(request.body?.decodeString() ?? "N/A")
             BODY_DICT: \(try request.body?.decodeJSONDictionary() ?? [:])
-            BODY_TYPE: \(try request.body?.decodeJSON(as: SampleJSON.self))
             """)
     }
 }

--- a/Tests/AlchemyTests/RouterTests.swift
+++ b/Tests/AlchemyTests/RouterTests.swift
@@ -218,7 +218,4 @@ struct Request {
     static let get1Queries = Request(method: .GET, path: "/something?some=value&other=2", response: "get 1")
     static let get2 = Request(method: .GET, path: "/something/else", response: "get 2")
     static let get3 = Request(method: .GET, path: "/something_else", response: "get 3")
-    
-    static let pathParameterEscaped = Request(method: .GET, path: "/parameter/:id", response: "path param")
-    static let pathParameterValue = Request(method: .GET, path: "/parameter/123", response: "path param")
 }


### PR DESCRIPTION
`HTTPRequest`s now have a `pathParameters` property that the router populates when matching.

The escape character for registering a path parameter in the router is `:`.

e.g.
`v1/some_path/:uuid/other_path/:user_id` will match `v1/some_path/4ca7fa23-203f-4d60-bcfd-6115353df05e/other_path/123` and set the `HTTPRequest`s `pathParameters` to

```swift
[
    PathParameter(parameter: "uuid", stringValue: "4ca7fa23-203f-4d60-bcfd-6115353df05e"),
    PathParameter(parameter: "user_id", stringValue: "123")
]
```

Maintaining the order in which the parameters were parsed.