### PR TITLE
Add command for creating a new migration

### DIFF
--- a/Sources/Alchemy/HTTPClient/Client.swift
+++ b/Sources/Alchemy/HTTPClient/Client.swift
@@ -1,7 +1,3 @@
-/// Something to make HTTP requests from the server.
-///
-/// Might not be necessary with the newly christened https://github.com/swift-server/async-http-client
-/// Haven't looked @ the docs but maybe they could be prettified.
 import AsyncHTTPClient
 import Fusion
 import NIO

--- a/Sources/CLI/AlchemyCLI.swift
+++ b/Sources/CLI/AlchemyCLI.swift
@@ -5,7 +5,7 @@ struct AlchemyCLI: ParsableCommand {
     public static var configuration: CommandConfiguration {
         CommandConfiguration(
             abstract: "An Alchemy CLI.",
-            subcommands: [NewProject.self]
+            subcommands: [NewProject.self, Migrate.self]
         )
     }
 }

--- a/Sources/CLI/Commands/Migrate.swift
+++ b/Sources/CLI/Commands/Migrate.swift
@@ -1,0 +1,58 @@
+import ArgumentParser
+import Foundation
+
+struct MigrationError: Error {
+    let info: String
+    
+    var description: String {
+        self.info
+    }
+}
+
+struct Migrate: ParsableCommand {
+    static var configuration = CommandConfiguration(
+        commandName: "migrate",
+        subcommands: [New.self]
+    )
+    
+    struct New: ParsableCommand {
+        @Argument
+        var name: String
+        
+        func run() throws {
+            guard let migrationLocations = try? Process().shell("find Sources -type d -name 'Migrations'").split(separator: "\n"),
+                  let migrationLocation = migrationLocations.first else
+            {
+                throw MigrationError(info: "No 'Migrations/' directory found. Please ensure you're in an Alchemy project directory.")
+            }
+            
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateFormat = "yyyyMMddHHmmss"
+            let fileName = "_\(dateFormatter.string(from: Date()))\(name)"
+            let template = self.migrationTemplate(name: fileName)
+
+            let destinationURL = URL(fileURLWithPath: "\(migrationLocation)/\(fileName).swift")
+            try template.write(to: destinationURL, atomically: true, encoding: .utf8)
+            print("Created migration '\(fileName)' at \(migrationLocation)")
+        }
+        
+        private func migrationTemplate(name: String) -> String {
+            """
+            struct \(name): Migration {
+                func up(schema: Schema) {
+                    schema.create(table: "users") {
+                        $0.uuid("id").primary()
+                        $0.string("name").nullable(false)
+                        $0.string("email").nullable(false).unique()
+                    }
+                }
+                
+                func down(schema: Schema) {
+                    schema.drop(table: "users")
+                }
+            }
+            """
+        }
+    }
+}
+

--- a/Sources/CLI/Commands/NewProject.swift
+++ b/Sources/CLI/Commands/NewProject.swift
@@ -48,9 +48,6 @@ struct NewProject: ParsableCommand {
     var name: String
     
     func run() throws {
-        let wd = try Process().shell("pwd")
-        print(wd)
-        
         print("Cloning quickstart project...")
         // Blow away the temp directory so git doesn't complain if it already exists.
         _ = try Process().shell("rm -rf \(kTempDirectory)")

--- a/Sources/CLI/Extensions/Process+Shell.swift
+++ b/Sources/CLI/Extensions/Process+Shell.swift
@@ -33,8 +33,6 @@ extension Process {
                 .reduce("") { $0 + String($1) }
                 .trimmingCharacters(in: .whitespacesAndNewlines)
         } else {
-            print("command: \(command)")
-            print("term: \(self.terminationStatus)")
             throw ShellError(output: error)
         }
     }


### PR DESCRIPTION
`alchemy migrate new <MigrationName>`

Results in a new migration file in the `Migrations/` folder of the current project. It will be titled `_yyyyMMddHHmmss<MigrationName>.swift` with a struct inside named the same.