### PR TITLE
Base `Application.launch` on Swift Service Lifecycle

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -92,6 +92,15 @@
         }
       },
       {
+        "package": "swift-backtrace",
+        "repositoryURL": "https://github.com/swift-server/swift-backtrace.git",
+        "state": {
+          "branch": null,
+          "revision": "f2fd8c4845a123419c348e0bc4b3839c414077d5",
+          "version": "1.2.0"
+        }
+      },
+      {
         "package": "swift-crypto",
         "repositoryURL": "https://github.com/apple/swift-crypto.git",
         "state": {
@@ -161,6 +170,15 @@
           "branch": null,
           "revision": "5a352330c09a323e59ebd99afdf4ca3964c217bc",
           "version": "1.9.1"
+        }
+      },
+      {
+        "package": "swift-service-lifecycle",
+        "repositoryURL": "https://github.com/swift-server/swift-service-lifecycle.git",
+        "state": {
+          "branch": null,
+          "revision": "a7356e142b083938c63e559b78e35f7f82627a79",
+          "version": "1.0.0-alpha.6"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -27,6 +27,7 @@ let package = Package(
         .package(url: "https://github.com/Alamofire/Alamofire", from: "5.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.3.0")),
         .package(name: "Plot", url: "https://github.com/johnsundell/plot.git", from: "0.8.0"),
+        .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "1.0.0-alpha"),
     ],
     targets: [
         .target(
@@ -44,6 +45,7 @@ let package = Package(
                 .product(name: "NIOHTTP2", package: "swift-nio-http2"),
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "Plot", package: "Plot"),
+                .product(name: "LifecycleNIOCompat", package: "swift-service-lifecycle"),
                 
                 /// Internal dependencies
                 "Papyrus",

--- a/Sources/Alchemy/Core/Application.swift
+++ b/Sources/Alchemy/Core/Application.swift
@@ -1,6 +1,6 @@
-/// Much of this is courtesy of [apple/swift-nio-examples](
-/// https://github.com/apple/swift-nio-examples/tree/main/http2-server/Sources/http2-server)
 import Fusion
+import Lifecycle
+import LifecycleNIOCompat
 import NIO
 import NIOHTTP1
 
@@ -47,50 +47,83 @@ enum StartupArgs {
 
 extension Application {
     /// Launch the application with the provided startup arguments. It will
-    /// either `serve` or `migrate`.
+    /// either serve or migrate.
     ///
     /// - Parameter args: what the application should do when it's launched.
     /// - Throws: any error that may be encountered in booting the application.
     func launch(_ args: StartupArgs) throws {
-        // Bootstrap core Alchemy services.
-        Services.bootstrap()
+        let lifecycle = ServiceLifecycle(
+            configuration: ServiceLifecycle.Configuration(
+                logger: Log.logger,
+                installBacktrace: true
+            )
+        )
         
-        // First, run `setup()` on an `EventLoop`.
-        let setup = Services.eventLoopGroup.next().submit(self.setup)
-            
-        switch args {
-        case .migrate(let rollback):
-            // Migrations need to be run on an `EventLoop`.
-            try setup.flatMap { self.migrate(rollback: rollback) }
-                .wait()
-            Log.info("Migrations finished!")
-        case .serve(let socket):
-            try setup.wait()
-            try self.startServing(socket: socket, group: Services.eventLoopGroup)
-        }
+        lifecycle.register(
+            label: "AlchemyCoreServices",
+            start: .sync { Services.bootstrap(lifecycle: lifecycle) },
+            shutdown: .sync(Services.shutdown)
+        )
         
-        try Services.shutdown()
+        lifecycle.register(
+            label: "AlchemySetup",
+            start: .sync { try Services.eventLoopGroup.next().submit(self.setup).wait() },
+            shutdown: .sync {}
+        )
+        
+        let runner: Runner = {
+            switch args {
+            case .migrate(let rollback):
+                return Migrator(rollback: rollback)
+            case .serve(let socket):
+                return Server(socket: socket)
+            }
+        }()
+        
+        lifecycle.register(
+            label: "\(Self.self)",
+            start: .eventLoopFuture(runner.start),
+            shutdown: .eventLoopFuture(runner.shutdown)
+        )
+        
+        try lifecycle.startAndWait()
     }
-    
-    /// Run migrations on `Services.db`, optionally rolling back the latest
-    /// batch.
+}
+
+/// An abstraction of an Alchemy program to run.
+private protocol Runner {
+    /// Start running.
     ///
-    /// - Parameter rollback: if true, the latest batch of migrations will be
-    ///                       rolled back
-    /// - Returns: an `EventLoopFuture<Void>` that completes when the migrations
-    ///            are finished.
-    private func migrate(rollback: Bool) -> EventLoopFuture<Void> {
-        rollback ? Services.db.rollbackMigrations() : Services.db.migrate()
+    /// - Returns: A future indicating that running has finished.
+    func start() -> EventLoopFuture<Void>
+    
+    /// Stop running, if possible.
+    ///
+    /// - Returns: A future indicating that shut down has finished.
+    func shutdown() -> EventLoopFuture<Void>
+}
+
+/// Runs a HTTP server, listening on a socket and routing incoming requests to `Services.router`.
+/// Server is the default `Runner` of an Alchemy application.
+private final class Server: Runner {
+    /// The socket to bind to.
+    private let socket: Socket
+    
+    /// A channel representing the connection to the socket of this server.
+    private var channel: Channel?
+    
+    /// Create a new server that will bind to the given socket.
+    ///
+    /// - Parameter socket: The socket this server will bind to and listen at.
+    init(socket: Socket) {
+        self.socket = socket
     }
+
+    // MARK: Runner
     
-    /// Start serving at the given target. Routing is handled by the singleton `HTTPRouter`.
-    ///
-    /// - Note: this function never unblocks for the lifecycle of the server.
-    /// - Parameters:
-    ///   - socket: the socket where the server should bind (listen for requests at).
-    ///   - group: a `MultiThreadedEventLoopGroup` for fetching `EventLoop`s to handle requests on.
-    /// - Throws: any errors encountered when bootstrapping the server.
-    private func startServing(socket: Socket, group: EventLoopGroup) throws {
+    func start() -> EventLoopFuture<Void> {
+        // Much of this is courtesy of [apple/swift-nio-examples](
+        // https://github.com/apple/swift-nio-examples/tree/main/http2-server/Sources/http2-server)
         func childChannelInitializer(
             channel: Channel
         ) -> EventLoopFuture<Void> {
@@ -101,12 +134,11 @@ extension Application {
                 }
         }
 
-        let serverBootstrap = ServerBootstrap(group: group)
+        let serverBootstrap = ServerBootstrap(group: Services.eventLoopGroup)
             // Specify backlog and enable SO_REUSEADDR for the server itself
             .serverChannelOption(ChannelOptions.backlog, value: 256)
             .serverChannelOption(
-                ChannelOptions
-                    .socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR),
+                ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR),
                 value: 1
             )
 
@@ -115,28 +147,51 @@ extension Application {
 
             // Enable SO_REUSEADDR for the accepted Channels
             .childChannelOption(
-                ChannelOptions
-                    .socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR),
-                value: 1)
+                ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR),
+                value: 1
+            )
             .childChannelOption(ChannelOptions.maxMessagesPerRead, value: 1)
 
-        let channel = try { () -> Channel in
+        let channel = { () -> EventLoopFuture<Channel> in
             switch socket {
             case .ip(let host, let port):
-                return try serverBootstrap.bind(host: host, port: port).wait()
+                return serverBootstrap.bind(host: host, port: port)
             case .unix(let path):
-                return try serverBootstrap.bind(unixDomainSocketPath: path)
-                    .wait()
+                return serverBootstrap.bind(unixDomainSocketPath: path)
             }
         }()
-
-        guard let channelLocalAddress = channel.localAddress else {
-            fatalError("Address was unable to bind. Please check that the socket was not closed or that the address family was understood.")
-        }
         
-        Log.info("Server started and listening on \(channelLocalAddress).")
+        return channel
+            .flatMap { boundChannel in
+                self.channel = boundChannel
+                guard let channelLocalAddress = boundChannel.localAddress else {
+                    fatalError("Address was unable to bind. Please check that the socket was not closed or that the address family was understood.")
+                }
+                
+                Log.info("[Server] started and listening on \(channelLocalAddress).")
+                return boundChannel.closeFuture
+            }
+    }
+    
+    func shutdown() -> EventLoopFuture<Void> {
+        self.channel?.close() ?? .new()
+    }
+}
 
-        // This will never unblock as we don't close the ServerChannel
-        try channel.closeFuture.wait()
+/// Run migrations on `Services.db`, optionally rolling back the latest batch.
+private struct Migrator: Runner {
+    /// Indicates whether migrations should be run (`false`) or rolled back (`true`).
+    let rollback: Bool
+    
+    // MARK: Runner
+    
+    func start() -> EventLoopFuture<Void> {
+        Services.eventLoopGroup
+            .next()
+            .flatSubmit(self.rollback ? Services.db.rollbackMigrations : Services.db.migrate)
+    }
+    
+    func shutdown() -> EventLoopFuture<Void> {
+        .new()
     }
 }

--- a/Sources/Alchemy/Core/Log.swift
+++ b/Sources/Alchemy/Core/Log.swift
@@ -1,7 +1,7 @@
 import Logging
 
 /// Convenience struct for logging logs of various levels to a default `Logger`.
-/// By default, this logger has label `alchemy_default_logger`.
+/// By default, this logger has label `Alchemy`.
 ///
 /// ```
 /// Log.debug("Hello, world!")
@@ -13,8 +13,8 @@ import Logging
 /// Log.logger = Logger(label: "my_default_logger")
 /// ```
 public struct Log {
-    /// The logger to which all logs will be logged. By default it's a logger with label `alchemy`.
-    public static var logger = Logger(label: "alchemy")
+    /// The logger to which all logs will be logged. By default it's a logger with label `Alchemy`.
+    public static var logger = Logger(label: "Alchemy")
     
     /// Log a message with the `Logger.Level.trace` log level.
     ///

--- a/Sources/Alchemy/SQL/Database/Postgres/Postgres+Database.swift
+++ b/Sources/Alchemy/SQL/Database/Postgres/Postgres+Database.swift
@@ -46,8 +46,7 @@ public final class PostgresDatabase: Database {
         _ sql: String,
         values: [DatabaseValue]
     ) -> EventLoopFuture<[DatabaseRow]> {
-        print(sql)
-        return self.pool.withConnection(logger: nil, on: Services.eventLoop) { conn in
+        self.pool.withConnection(logger: nil, on: Services.eventLoop) { conn in
             conn.query(self.positionBindings(sql), values.map(PostgresData.init) )
                 .map { $0.rows }
         }

--- a/Sources/Alchemy/Utilities/EventLoopFuture+Utilities.swift
+++ b/Sources/Alchemy/Utilities/EventLoopFuture+Utilities.swift
@@ -26,6 +26,15 @@ extension EventLoopFuture {
     }
 }
 
+extension EventLoopFuture where Value == Void {
+    /// Creates a new successed `EventLoopFuture` on the current `EventLoop`.
+    ///
+    /// - Returns: a created future that will resolve immediately.
+    public static func new() -> EventLoopFuture<Void> {
+        .new(())
+    }
+}
+
 /// Takes a throwing block & returns either the `EventLoopFuture<T>` that block creates or an errored
 /// `EventLoopFuture<T>` if the closure threw an error.
 ///

--- a/Sources/Alchemy/Utilities/Services.swift
+++ b/Sources/Alchemy/Utilities/Services.swift
@@ -1,5 +1,6 @@
 import AsyncHTTPClient
 import Fusion
+import Lifecycle
 import NIO
 
 /// Provides easy access to some commonly used services in Alchemy. These services are Injected from
@@ -98,8 +99,13 @@ extension Services {
         Container.global.resolve(NIOThreadPool.self)
     }
     
+    /// A `ServiceLifecycle` hooking into this application's lifecycle.
+    public static var lifecycle: ServiceLifecycle {
+        Container.global.resolve(ServiceLifecycle.self)
+    }
+    
     /// Register some commonly used services to `Container.global`.
-    internal static func bootstrap() {
+    internal static func bootstrap(lifecycle: ServiceLifecycle) {
         // `Router`
         Container.global.register(singleton: Router.self) { _ in
             Router()
@@ -135,6 +141,11 @@ extension Services {
             let pool = NIOThreadPool(numberOfThreads: System.coreCount)
             pool.start()
             return pool
+        }
+        
+        // `ServiceLifecycle`
+        Container.global.register(singleton: ServiceLifecycle.self) { _ in
+            return lifecycle
         }
     }
     


### PR DESCRIPTION
[Swift Service Lifecycle](https://github.com/swift-server/swift-service-lifecycle).

Keeps things more elegant and hopefully easier to follow. Also has built in support for [Backtrace](https://github.com/swift-server/swift-backtrace) which is nice.

Application now launches a `Runner` (aka a runnable program, right now either `Server` or `Migrator` depending on the launch command).

`start` order is...
Services.bootstrap (which also registers `Lifecycle` as a service, should the user want to hook into it)
Application.setup
Runner.start

`shutdown` order is...
Runner.shutdown
Services.shutdown



